### PR TITLE
Refactor: IOPath Cleanup and loggerextension.cs + logging infrastructure streamline

### DIFF
--- a/Common/LoggerExtensions.cs
+++ b/Common/LoggerExtensions.cs
@@ -1,0 +1,40 @@
+using Playnite.SDK;
+
+namespace UniPlaySong.Common
+{
+    /// <summary>
+    /// Extension methods for ILogger to provide conditional debug logging
+    /// </summary>
+    public static class LoggerExtensions
+    {
+        /// <summary>
+        /// Logs a debug message with a prefix only if debug logging is enabled in settings.
+        /// Centralizes the conditional debug logging pattern used throughout the codebase.
+        /// </summary>
+        /// <param name="logger">The logger instance</param>
+        /// <param name="prefix">The component prefix (e.g., "Amplify", "PreciseTrim")</param>
+        /// <param name="message">The debug message to log</param>
+        public static void DebugIf(this ILogger logger, string prefix, string message)
+        {
+            if (FileLogger.IsDebugLoggingEnabled)
+            {
+                logger.Debug($"[{prefix}] {message}");
+            }
+        }
+
+        /// <summary>
+        /// Logs a debug message with exception and prefix only if debug logging is enabled.
+        /// </summary>
+        /// <param name="logger">The logger instance</param>
+        /// <param name="prefix">The component prefix</param>
+        /// <param name="ex">The exception to log</param>
+        /// <param name="message">The debug message to log</param>
+        public static void DebugIf(this ILogger logger, string prefix, System.Exception ex, string message)
+        {
+            if (FileLogger.IsDebugLoggingEnabled)
+            {
+                logger.Debug(ex, $"[{prefix}] {message}");
+            }
+        }
+    }
+}

--- a/Handlers/AmplifyDialogHandler.cs
+++ b/Handlers/AmplifyDialogHandler.cs
@@ -13,14 +13,7 @@ namespace UniPlaySong.Handlers
     public class AmplifyDialogHandler
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug($"[Amplify] {message}");
-            }
-        }
+        private const string LogPrefix = "Amplify";
 
         private readonly IPlayniteAPI _playniteApi;
         private readonly Func<UniPlaySongSettings> _settingsProvider;
@@ -49,7 +42,7 @@ namespace UniPlaySong.Handlers
         {
             try
             {
-                LogDebug($"ShowAmplifyDialog called for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix,$"ShowAmplifyDialog called for game: {game?.Name}");
 
                 if (game == null)
                 {
@@ -59,7 +52,7 @@ namespace UniPlaySong.Handlers
 
                 // Check if there are any songs
                 var availableSongs = _fileService?.GetAvailableSongs(game) ?? new List<string>();
-                LogDebug($"Found {availableSongs.Count} available songs for game");
+                Logger.DebugIf(LogPrefix,$"Found {availableSongs.Count} available songs for game");
                 if (availableSongs.Count == 0)
                 {
                     _playniteApi.Dialogs.ShowMessage(
@@ -71,7 +64,7 @@ namespace UniPlaySong.Handlers
                 // Validate FFmpeg
                 var settings = _settingsProvider?.Invoke();
                 var ffmpegPath = settings?.FFmpegPath;
-                LogDebug($"FFmpeg path from settings: {ffmpegPath}");
+                Logger.DebugIf(LogPrefix,$"FFmpeg path from settings: {ffmpegPath}");
                 if (string.IsNullOrEmpty(ffmpegPath) || !_amplifyService.ValidateFFmpegAvailable(ffmpegPath))
                 {
                     _playniteApi.Dialogs.ShowErrorMessage(
@@ -82,11 +75,11 @@ namespace UniPlaySong.Handlers
                 }
 
                 // Stop current playback
-                LogDebug("Stopping current playback");
+                Logger.DebugIf(LogPrefix,"Stopping current playback");
                 _playbackService?.Stop();
 
                 // Create and show dialog
-                LogDebug("Creating desktop AmplifyDialog");
+                Logger.DebugIf(LogPrefix,"Creating desktop AmplifyDialog");
                 var dialog = new Views.AmplifyDialog();
                 var window = DialogHelper.CreateStandardDialog(
                     _playniteApi,
@@ -106,15 +99,15 @@ namespace UniPlaySong.Handlers
                 // Handle window closing
                 window.Closing += (s, e) =>
                 {
-                    LogDebug("Desktop dialog closing, running cleanup");
+                    Logger.DebugIf(LogPrefix,"Desktop dialog closing, running cleanup");
                     dialog.Cleanup();
                 };
 
                 DialogHelper.AddFocusReturnHandler(window, _playniteApi, "amplify dialog close");
 
-                LogDebug("Showing desktop dialog");
+                Logger.DebugIf(LogPrefix,"Showing desktop dialog");
                 window.ShowDialog();
-                LogDebug("Desktop dialog closed");
+                Logger.DebugIf(LogPrefix,"Desktop dialog closed");
             }
             catch (Exception ex)
             {
@@ -132,7 +125,7 @@ namespace UniPlaySong.Handlers
         {
             try
             {
-                LogDebug($"ShowControllerAmplifyDialog called for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix,$"ShowControllerAmplifyDialog called for game: {game?.Name}");
 
                 if (game == null)
                 {
@@ -142,7 +135,7 @@ namespace UniPlaySong.Handlers
 
                 // Check if there are any songs
                 var availableSongs = _fileService?.GetAvailableSongs(game) ?? new List<string>();
-                LogDebug($"Found {availableSongs.Count} available songs for game");
+                Logger.DebugIf(LogPrefix,$"Found {availableSongs.Count} available songs for game");
                 if (availableSongs.Count == 0)
                 {
                     _playniteApi.Dialogs.ShowMessage(
@@ -154,7 +147,7 @@ namespace UniPlaySong.Handlers
                 // Validate FFmpeg
                 var settings = _settingsProvider?.Invoke();
                 var ffmpegPath = settings?.FFmpegPath;
-                LogDebug($"FFmpeg path from settings: {ffmpegPath}");
+                Logger.DebugIf(LogPrefix,$"FFmpeg path from settings: {ffmpegPath}");
                 if (string.IsNullOrEmpty(ffmpegPath) || !_amplifyService.ValidateFFmpegAvailable(ffmpegPath))
                 {
                     _playniteApi.Dialogs.ShowErrorMessage(
@@ -165,11 +158,11 @@ namespace UniPlaySong.Handlers
                 }
 
                 // Stop current playback
-                LogDebug("Stopping current playback");
+                Logger.DebugIf(LogPrefix,"Stopping current playback");
                 _playbackService?.Stop();
 
                 // Create and show controller dialog
-                LogDebug("Creating controller ControllerAmplifyDialog");
+                Logger.DebugIf(LogPrefix,"Creating controller ControllerAmplifyDialog");
                 var dialog = new Views.ControllerAmplifyDialog();
                 var window = DialogHelper.CreateFixedDialog(
                     _playniteApi,
@@ -188,9 +181,9 @@ namespace UniPlaySong.Handlers
 
                 DialogHelper.AddFocusReturnHandler(window, _playniteApi, "controller amplify dialog close");
 
-                LogDebug("Showing controller dialog");
+                Logger.DebugIf(LogPrefix,"Showing controller dialog");
                 window.ShowDialog();
-                LogDebug("Controller dialog closed");
+                Logger.DebugIf(LogPrefix,"Controller dialog closed");
             }
             catch (Exception ex)
             {

--- a/Handlers/WaveformTrimDialogHandler.cs
+++ b/Handlers/WaveformTrimDialogHandler.cs
@@ -13,17 +13,7 @@ namespace UniPlaySong.Handlers
     public class WaveformTrimDialogHandler
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        /// <summary>
-        /// Logs a debug message only if debug logging is enabled in settings.
-        /// </summary>
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug($"[PreciseTrim] {message}");
-            }
-        }
+        private const string LogPrefix = "PreciseTrim";
 
         private readonly IPlayniteAPI _playniteApi;
         private readonly Func<UniPlaySongSettings> _settingsProvider;
@@ -52,18 +42,18 @@ namespace UniPlaySong.Handlers
         {
             try
             {
-                LogDebug($"ShowPreciseTrimDialog called for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix,$"ShowPreciseTrimDialog called for game: {game?.Name}");
 
                 if (game == null)
                 {
-                    LogDebug("No game selected, showing error");
+                    Logger.DebugIf(LogPrefix,"No game selected, showing error");
                     _playniteApi.Dialogs.ShowMessage("No game selected.", "Precise Trim");
                     return;
                 }
 
                 // Check if there are any songs
                 var availableSongs = _fileService?.GetAvailableSongs(game) ?? new List<string>();
-                LogDebug($"Found {availableSongs.Count} available songs for game");
+                Logger.DebugIf(LogPrefix,$"Found {availableSongs.Count} available songs for game");
                 if (availableSongs.Count == 0)
                 {
                     _playniteApi.Dialogs.ShowMessage(
@@ -75,10 +65,10 @@ namespace UniPlaySong.Handlers
                 // Validate FFmpeg
                 var settings = _settingsProvider?.Invoke();
                 var ffmpegPath = settings?.FFmpegPath;
-                LogDebug($"FFmpeg path from settings: {ffmpegPath}");
+                Logger.DebugIf(LogPrefix,$"FFmpeg path from settings: {ffmpegPath}");
                 if (string.IsNullOrEmpty(ffmpegPath) || !_waveformTrimService.ValidateFFmpegAvailable(ffmpegPath))
                 {
-                    LogDebug("FFmpeg validation failed");
+                    Logger.DebugIf(LogPrefix,"FFmpeg validation failed");
                     _playniteApi.Dialogs.ShowErrorMessage(
                         "FFmpeg is required for precise trimming.\n\n" +
                         "Please configure FFmpeg path in Settings → Audio Normalization.",
@@ -87,11 +77,11 @@ namespace UniPlaySong.Handlers
                 }
 
                 // Stop current playback
-                LogDebug("Stopping current playback");
+                Logger.DebugIf(LogPrefix,"Stopping current playback");
                 _playbackService?.Stop();
 
                 // Create and show dialog
-                LogDebug("Creating desktop WaveformTrimDialog");
+                Logger.DebugIf(LogPrefix,"Creating desktop WaveformTrimDialog");
                 var dialog = new Views.WaveformTrimDialog();
                 var window = DialogHelper.CreateStandardDialog(
                     _playniteApi,
@@ -111,15 +101,15 @@ namespace UniPlaySong.Handlers
                 // Handle window closing
                 window.Closing += (s, e) =>
                 {
-                    LogDebug("Desktop dialog closing, running cleanup");
+                    Logger.DebugIf(LogPrefix,"Desktop dialog closing, running cleanup");
                     dialog.Cleanup();
                 };
 
                 DialogHelper.AddFocusReturnHandler(window, _playniteApi, "precise trim dialog close");
 
-                LogDebug("Showing desktop dialog");
+                Logger.DebugIf(LogPrefix,"Showing desktop dialog");
                 window.ShowDialog();
-                LogDebug("Desktop dialog closed");
+                Logger.DebugIf(LogPrefix,"Desktop dialog closed");
             }
             catch (Exception ex)
             {
@@ -137,18 +127,18 @@ namespace UniPlaySong.Handlers
         {
             try
             {
-                LogDebug($"ShowControllerPreciseTrimDialog called for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix,$"ShowControllerPreciseTrimDialog called for game: {game?.Name}");
 
                 if (game == null)
                 {
-                    LogDebug("No game selected, showing error");
+                    Logger.DebugIf(LogPrefix,"No game selected, showing error");
                     _playniteApi.Dialogs.ShowMessage("No game selected.", "Precise Trim");
                     return;
                 }
 
                 // Check if there are any songs
                 var availableSongs = _fileService?.GetAvailableSongs(game) ?? new List<string>();
-                LogDebug($"Found {availableSongs.Count} available songs for game");
+                Logger.DebugIf(LogPrefix,$"Found {availableSongs.Count} available songs for game");
                 if (availableSongs.Count == 0)
                 {
                     _playniteApi.Dialogs.ShowMessage(
@@ -160,10 +150,10 @@ namespace UniPlaySong.Handlers
                 // Validate FFmpeg
                 var settings = _settingsProvider?.Invoke();
                 var ffmpegPath = settings?.FFmpegPath;
-                LogDebug($"FFmpeg path from settings: {ffmpegPath}");
+                Logger.DebugIf(LogPrefix,$"FFmpeg path from settings: {ffmpegPath}");
                 if (string.IsNullOrEmpty(ffmpegPath) || !_waveformTrimService.ValidateFFmpegAvailable(ffmpegPath))
                 {
-                    LogDebug("FFmpeg validation failed");
+                    Logger.DebugIf(LogPrefix,"FFmpeg validation failed");
                     _playniteApi.Dialogs.ShowErrorMessage(
                         "FFmpeg is required for precise trimming.\n\n" +
                         "Please configure FFmpeg path in Settings → Audio Normalization.",
@@ -172,11 +162,11 @@ namespace UniPlaySong.Handlers
                 }
 
                 // Stop current playback
-                LogDebug("Stopping current playback");
+                Logger.DebugIf(LogPrefix,"Stopping current playback");
                 _playbackService?.Stop();
 
                 // Create and show controller dialog
-                LogDebug("Creating controller ControllerWaveformTrimDialog");
+                Logger.DebugIf(LogPrefix,"Creating controller ControllerWaveformTrimDialog");
                 var dialog = new Views.ControllerWaveformTrimDialog();
                 var window = DialogHelper.CreateFixedDialog(
                     _playniteApi,
@@ -195,9 +185,9 @@ namespace UniPlaySong.Handlers
 
                 DialogHelper.AddFocusReturnHandler(window, _playniteApi, "controller precise trim dialog close");
 
-                LogDebug("Showing controller dialog");
+                Logger.DebugIf(LogPrefix,"Showing controller dialog");
                 window.ShowDialog();
-                LogDebug("Controller dialog closed");
+                Logger.DebugIf(LogPrefix,"Controller dialog closed");
             }
             catch (Exception ex)
             {

--- a/Services/AmplifyPreviewPlayer.cs
+++ b/Services/AmplifyPreviewPlayer.cs
@@ -13,21 +13,14 @@ namespace UniPlaySong.Services
     public class AmplifyPreviewPlayer : IDisposable
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
+        private const string LogPrefix = "AmplifyPreview";
 
         private MusicPlayer _player;
         private bool _isDisposed;
 
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug($"[AmplifyPreview] {message}");
-            }
-        }
-
         public AmplifyPreviewPlayer()
         {
-            LogDebug("AmplifyPreviewPlayer created");
+            Logger.DebugIf(LogPrefix,"AmplifyPreviewPlayer created");
         }
 
         /// <summary>
@@ -54,7 +47,7 @@ namespace UniPlaySong.Services
                 // Clamp volume to valid range
                 volume = Math.Max(0.0, Math.Min(1.0, volume));
 
-                LogDebug($"Playing {Path.GetFileName(filePath)} at volume {volume:F2}");
+                Logger.DebugIf(LogPrefix,$"Playing {Path.GetFileName(filePath)} at volume {volume:F2}");
 
                 // Create new player instance (same pattern as DownloadDialogViewModel)
                 _player = new MusicPlayer();
@@ -66,7 +59,7 @@ namespace UniPlaySong.Services
                 _player.Load(filePath);
                 _player.Play();
 
-                LogDebug($"Playback started successfully at volume {volume:F2}");
+                Logger.DebugIf(LogPrefix,$"Playback started successfully at volume {volume:F2}");
             }
             catch (Exception ex)
             {
@@ -91,7 +84,7 @@ namespace UniPlaySong.Services
                     _player = null;
                 }
 
-                LogDebug("Playback stopped");
+                Logger.DebugIf(LogPrefix,"Playback stopped");
             }
             catch (Exception ex)
             {
@@ -109,7 +102,7 @@ namespace UniPlaySong.Services
             if (_isDisposed) return;
             _isDisposed = true;
 
-            LogDebug("Disposing AmplifyPreviewPlayer");
+            Logger.DebugIf(LogPrefix,"Disposing AmplifyPreviewPlayer");
             Stop();
         }
     }

--- a/Services/DownloadDialogService.cs
+++ b/Services/DownloadDialogService.cs
@@ -21,17 +21,7 @@ namespace UniPlaySong.Services
     public class DownloadDialogService
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        /// <summary>
-        /// Logs a debug message only if debug logging is enabled in settings.
-        /// </summary>
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
+        private const string LogPrefix = "DownloadDialog";
 
         private readonly IPlayniteAPI _playniteApi;
         private readonly IDownloadManager _downloadManager;
@@ -215,16 +205,16 @@ namespace UniPlaySong.Services
                     var selectedItem = selected[0];
                     if (selectedItem is Playnite.SDK.GenericItemOption selectedOption)
                     {
-                        LogDebug($"User selected source option: {selectedOption.Name}");
+                        Logger.DebugIf(LogPrefix,$"User selected source option: {selectedOption.Name}");
 
                         if (selectedOption.Name == "KHInsider")
                         {
-                            LogDebug("Returning Source.KHInsider");
+                            Logger.DebugIf(LogPrefix,"Returning Source.KHInsider");
                             return Source.KHInsider;
                         }
                         else if (selectedOption.Name == "YouTube")
                         {
-                            LogDebug("YouTube selected - validating configuration...");
+                            Logger.DebugIf(LogPrefix,"YouTube selected - validating configuration...");
                             // Validate YouTube configuration before returning
                             if (_settingsService.Current == null || string.IsNullOrWhiteSpace(_settingsService.Current.YtDlpPath) || string.IsNullOrWhiteSpace(_settingsService.Current.FFmpegPath))
                             {
@@ -246,7 +236,7 @@ namespace UniPlaySong.Services
                                 return null; // Prevent proceeding if yt-dlp not found
                             }
                             
-                            LogDebug("YouTube configuration validated successfully");
+                            Logger.DebugIf(LogPrefix,"YouTube configuration validated successfully");
                             return Source.YouTube;
                         }
                         else
@@ -266,7 +256,7 @@ namespace UniPlaySong.Services
             }
             else
             {
-                LogDebug("Source selection dialog cancelled or closed");
+                Logger.DebugIf(LogPrefix,"Source selection dialog cancelled or closed");
             }
 
             return null;
@@ -281,9 +271,9 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
 
-            LogDebug($"ShowUnifiedAlbumSelectionDialog called for game: {game?.Name ?? "null"}");
+            Logger.DebugIf(LogPrefix,$"ShowUnifiedAlbumSelectionDialog called for game: {game?.Name ?? "null"}");
 
-            LogDebug("Creating unified DownloadDialogViewModel...");
+            Logger.DebugIf(LogPrefix,"Creating unified DownloadDialogViewModel...");
             DownloadDialogViewModel viewModel = _errorHandler.Try(
                 () => new DownloadDialogViewModel(
                     _playniteApi,
@@ -305,7 +295,7 @@ namespace UniPlaySong.Services
                 return null;
             }
 
-            LogDebug("Unified DownloadDialogViewModel created successfully");
+            Logger.DebugIf(LogPrefix,"Unified DownloadDialogViewModel created successfully");
 
             return _errorHandler.Try(
                 () =>
@@ -341,7 +331,7 @@ namespace UniPlaySong.Services
                             {
                                 window.Activate();
                                 window.Focus();
-                                LogDebug("Unified album selection window loaded and activated");
+                                Logger.DebugIf(LogPrefix,"Unified album selection window loaded and activated");
 
                                 // Trigger search after window is loaded
                                 if (game != null)
@@ -390,9 +380,9 @@ namespace UniPlaySong.Services
                         viewModel.CleanupPreviewFiles();
                     };
 
-                    LogDebug("Showing unified album selection window...");
+                    Logger.DebugIf(LogPrefix,"Showing unified album selection window...");
                     var result = window.ShowDialog();
-                    LogDebug($"Unified album selection window closed with result: {result}");
+                    Logger.DebugIf(LogPrefix,$"Unified album selection window closed with result: {result}");
 
                     if (result == true)
                     {
@@ -400,12 +390,12 @@ namespace UniPlaySong.Services
                         var album = selected.FirstOrDefault() as Album;
                         if (album != null)
                         {
-                            LogDebug($"User selected album: {album.Name} from {album.Source}");
+                            Logger.DebugIf(LogPrefix,$"User selected album: {album.Name} from {album.Source}");
                             return album;
                         }
                     }
 
-                    LogDebug("User cancelled unified album selection or no album selected");
+                    Logger.DebugIf(LogPrefix,"User cancelled unified album selection or no album selected");
                     return null;
                 },
                 defaultValue: null,
@@ -422,16 +412,16 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
             
-            LogDebug($"ShowAlbumSelectionDialog called for game: {game?.Name ?? "null"}, source: {source}");
+            Logger.DebugIf(LogPrefix,$"ShowAlbumSelectionDialog called for game: {game?.Name ?? "null"}, source: {source}");
             
             // YouTube configuration is now validated in ShowSourceSelectionDialog before YouTube can be selected
             // So if we reach here with YouTube source, it should be valid
             if (source == Source.YouTube)
             {
-                LogDebug("YouTube source confirmed - configuration already validated");
+                Logger.DebugIf(LogPrefix,"YouTube source confirmed - configuration already validated");
             }
 
-            LogDebug("Creating DownloadDialogViewModel...");
+            Logger.DebugIf(LogPrefix,"Creating DownloadDialogViewModel...");
             DownloadDialogViewModel viewModel = _errorHandler.Try(
                 () => new DownloadDialogViewModel(
                     _playniteApi,
@@ -453,9 +443,9 @@ namespace UniPlaySong.Services
                 return null;
             }
             
-            LogDebug("DownloadDialogViewModel created successfully");
+            Logger.DebugIf(LogPrefix,"DownloadDialogViewModel created successfully");
             
-            LogDebug("Creating album selection window...");
+            Logger.DebugIf(LogPrefix,"Creating album selection window...");
 
             return _errorHandler.Try(
                 () =>
@@ -492,7 +482,7 @@ namespace UniPlaySong.Services
                             {
                                 window.Activate();
                                 window.Focus();
-                                LogDebug("Album selection window loaded and activated");
+                                Logger.DebugIf(LogPrefix,"Album selection window loaded and activated");
                                 
                                 // Trigger search after window is loaded (similar to PNS WindowOpenedCommand)
                                 // This ensures window is visible and responsive before search starts
@@ -561,16 +551,16 @@ namespace UniPlaySong.Services
                         viewModel.CleanupPreviewFiles();
                     };
 
-                    LogDebug("Showing album selection dialog...");
+                    Logger.DebugIf(LogPrefix,"Showing album selection dialog...");
                     var result = window.ShowDialog();
-                    LogDebug($"Album selection dialog result: {result}");
+                    Logger.DebugIf(LogPrefix,$"Album selection dialog result: {result}");
                 
                     if (result == true)
                     {
                         // If double-clicked, use that album
                         if (doubleClickedAlbum != null)
                         {
-                            LogDebug($"Album double-clicked: {doubleClickedAlbum.Name}");
+                            Logger.DebugIf(LogPrefix,$"Album double-clicked: {doubleClickedAlbum.Name}");
                             return doubleClickedAlbum;
                         }
 
@@ -578,11 +568,11 @@ namespace UniPlaySong.Services
                         var album = selected.FirstOrDefault() as Album;
                         if (album != null)
                         {
-                            LogDebug($"Album selected: {album.Name} (ID: {album.Id})");
+                            Logger.DebugIf(LogPrefix,$"Album selected: {album.Name} (ID: {album.Id})");
                         }
                         else
                         {
-                            LogDebug("No album selected from dialog");
+                            Logger.DebugIf(LogPrefix,"No album selected from dialog");
                         }
                         return album;
                     }
@@ -590,11 +580,11 @@ namespace UniPlaySong.Services
                     // Return BackSignal when Back is pressed - signals caller to go back to source selection
                     if (viewModel.BackWasPressed)
                     {
-                        LogDebug("Album selection dialog: user pressed back - returning to source selection");
+                        Logger.DebugIf(LogPrefix,"Album selection dialog: user pressed back - returning to source selection");
                         return Album.BackSignal;
                     }
 
-                    LogDebug("Album selection dialog cancelled");
+                    Logger.DebugIf(LogPrefix,"Album selection dialog cancelled");
                     return null;
                 },
                 defaultValue: null,
@@ -654,7 +644,7 @@ namespace UniPlaySong.Services
                     {
                         window.Activate();
                         window.Focus();
-                        LogDebug("Song selection window loaded and activated");
+                        Logger.DebugIf(LogPrefix,"Song selection window loaded and activated");
                         
                         // Trigger search after window is loaded to load songs from album
                         // This matches the pattern we use for album selection
@@ -668,7 +658,7 @@ namespace UniPlaySong.Services
                                     _errorHandler.Try(
                                         () =>
                                         {
-                                            LogDebug($"Triggering song search for album: {album.Name}");
+                                            Logger.DebugIf(LogPrefix,$"Triggering song search for album: {album.Name}");
                                             viewModel.PerformSearch();
                                         },
                                         context: "auto-search for songs after window load"
@@ -702,7 +692,7 @@ namespace UniPlaySong.Services
                     _errorHandler.Try(
                         () =>
                         {
-                            LogDebug($"Download complete - triggering music refresh for game: {game.Name}");
+                            Logger.DebugIf(LogPrefix,$"Download complete - triggering music refresh for game: {game.Name}");
                             // Get current settings to pass to PlayGameMusic
                             var settings = _settingsService?.Current;
                             _playbackService.PlayGameMusic(game, settings, forceReload: true);
@@ -723,7 +713,7 @@ namespace UniPlaySong.Services
                     try
                     {
                         _tagService.UpdateGameMusicTag(game);
-                        LogDebug($"Updated music tag for game '{game.Name}' after download");
+                        Logger.DebugIf(LogPrefix,$"Updated music tag for game '{game.Name}' after download");
                     }
                     catch (Exception ex)
                     {
@@ -765,7 +755,7 @@ namespace UniPlaySong.Services
             // Return null when Back is pressed - signals caller to go back to album selection
             if (viewModel.BackWasPressed)
             {
-                LogDebug("Song selection dialog: user pressed back - returning to album selection");
+                Logger.DebugIf(LogPrefix,"Song selection dialog: user pressed back - returning to album selection");
                 return null;
             }
 
@@ -782,7 +772,7 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
 
-            LogDebug($"ShowSongSelectionDialogWithReturn called for game: {game?.Name ?? "null"}, album: {album?.Name ?? "null"}");
+            Logger.DebugIf(LogPrefix,$"ShowSongSelectionDialogWithReturn called for game: {game?.Name ?? "null"}, album: {album?.Name ?? "null"}");
 
             DownloadDialogViewModel viewModel = _errorHandler.Try(
                 () => new DownloadDialogViewModel(
@@ -837,7 +827,7 @@ namespace UniPlaySong.Services
                     {
                         window.Activate();
                         window.Focus();
-                        LogDebug("Batch song selection window loaded and activated");
+                        Logger.DebugIf(LogPrefix,"Batch song selection window loaded and activated");
 
                         if (album != null)
                         {
@@ -849,7 +839,7 @@ namespace UniPlaySong.Services
                                     _errorHandler.Try(
                                         () =>
                                         {
-                                            LogDebug($"Triggering song search for album: {album.Name}");
+                                            Logger.DebugIf(LogPrefix,$"Triggering song search for album: {album.Name}");
                                             viewModel.PerformSearch();
                                         },
                                         context: "auto-search for songs in batch dialog"
@@ -900,7 +890,7 @@ namespace UniPlaySong.Services
             
             if (result == true)
             {
-                LogDebug($"User selected {selectedSongs.Count} songs for batch download");
+                Logger.DebugIf(LogPrefix,$"User selected {selectedSongs.Count} songs for batch download");
                 return selectedSongs;
             }
 
@@ -916,7 +906,7 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
 
-            LogDebug("ShowDefaultMusicDownloadDialog called");
+            Logger.DebugIf(LogPrefix,"ShowDefaultMusicDownloadDialog called");
 
             if (_downloadManager == null)
             {
@@ -928,12 +918,12 @@ namespace UniPlaySong.Services
             Source? sourceNullable = ShowSourceSelectionDialog();
             if (sourceNullable == null)
             {
-                LogDebug("User cancelled source selection");
+                Logger.DebugIf(LogPrefix,"User cancelled source selection");
                 return false;
             }
 
             var source = sourceNullable.Value;
-            LogDebug($"User selected source: {source}");
+            Logger.DebugIf(LogPrefix,$"User selected source: {source}");
 
             // Step 2: For default music, use a dummy game and let users search in the album dialog
             // This is more intuitive - users can type the game name in the search box
@@ -943,7 +933,7 @@ namespace UniPlaySong.Services
             Album album = ShowAlbumSelectionDialogForDefaultMusic(source);
             if (album == null)
             {
-                LogDebug("User cancelled album selection");
+                Logger.DebugIf(LogPrefix,"User cancelled album selection");
                 return false;
             }
 
@@ -951,7 +941,7 @@ namespace UniPlaySong.Services
             var selectedSong = ShowSongSelectionForDefaultMusic(dummyGame, album);
             if (selectedSong == null)
             {
-                LogDebug("No song selected or download cancelled");
+                Logger.DebugIf(LogPrefix,"No song selected or download cancelled");
                 return false;
             }
 
@@ -980,7 +970,7 @@ namespace UniPlaySong.Services
                         downloadPath = defaultMusicPath;
                     }
 
-                    LogDebug($"Downloading default music to: {downloadPath}");
+                    Logger.DebugIf(LogPrefix,$"Downloading default music to: {downloadPath}");
 
                     // Show progress dialog
                     var progressOptions = new Playnite.SDK.GlobalProgressOptions(
@@ -997,7 +987,7 @@ namespace UniPlaySong.Services
 
                     if (downloadSuccess && System.IO.File.Exists(downloadPath))
                     {
-                        LogDebug($"Default music downloaded successfully: {downloadPath}");
+                        Logger.DebugIf(LogPrefix,$"Default music downloaded successfully: {downloadPath}");
                         _playniteApi.Dialogs.ShowMessage(
                             $"Default music downloaded successfully!\n\nFile: {System.IO.Path.GetFileName(downloadPath)}\nLocation: {downloadPath}",
                             "Download Complete");
@@ -1027,7 +1017,7 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
 
-            LogDebug($"ShowSongSelectionForDefaultMusic called for game: {game?.Name ?? "null"}, album: {album?.Name ?? "null"}");
+            Logger.DebugIf(LogPrefix,$"ShowSongSelectionForDefaultMusic called for game: {game?.Name ?? "null"}, album: {album?.Name ?? "null"}");
 
             DownloadDialogViewModel viewModel = _errorHandler.Try(
                 () => new DownloadDialogViewModel(
@@ -1050,7 +1040,7 @@ namespace UniPlaySong.Services
                 return null;
             }
             
-            LogDebug("DownloadDialogViewModel created successfully");
+            Logger.DebugIf(LogPrefix,"DownloadDialogViewModel created successfully");
 
             var window = _playniteApi.Dialogs.CreateWindow(new WindowCreationOptions
             {
@@ -1084,7 +1074,7 @@ namespace UniPlaySong.Services
                     {
                         window.Activate();
                         window.Focus();
-                        LogDebug("Default music song selection window loaded and activated");
+                        Logger.DebugIf(LogPrefix,"Default music song selection window loaded and activated");
                         
                         // Trigger search after window is loaded to load songs from album
                         if (album != null)
@@ -1097,7 +1087,7 @@ namespace UniPlaySong.Services
                                     _errorHandler.Try(
                                         () =>
                                         {
-                                            LogDebug($"Triggering song search for album: {album.Name}");
+                                            Logger.DebugIf(LogPrefix,$"Triggering song search for album: {album.Name}");
                                             viewModel.PerformSearch();
                                         },
                                         context: "auto-search for songs in default music dialog"
@@ -1149,7 +1139,7 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
             
-            LogDebug($"ShowAlbumSelectionDialogForDefaultMusic called for source: {source}");
+            Logger.DebugIf(LogPrefix,$"ShowAlbumSelectionDialogForDefaultMusic called for source: {source}");
 
             // Create a dummy game with empty name - user will search
             Game dummyGame = new Game { Name = "", Id = Guid.NewGuid() };
@@ -1175,7 +1165,7 @@ namespace UniPlaySong.Services
                 return null;
             }
             
-            LogDebug("DownloadDialogViewModel created successfully");
+            Logger.DebugIf(LogPrefix,"DownloadDialogViewModel created successfully");
 
             var window = _playniteApi.Dialogs.CreateWindow(new WindowCreationOptions
             {
@@ -1216,7 +1206,7 @@ namespace UniPlaySong.Services
                     {
                         window.Activate();
                         window.Focus();
-                        LogDebug("Default music album selection window loaded");
+                        Logger.DebugIf(LogPrefix,"Default music album selection window loaded");
                         // Don't trigger auto-search - user will type in search box
                     },
                     context: "activating default music album selection window"
@@ -1270,7 +1260,7 @@ namespace UniPlaySong.Services
             // Pre-load Material Design assemblies before XAML parsing
             PreloadMaterialDesignAssemblies();
 
-            LogDebug($"ShowDownloadFromUrlDialog called for game: {game.Name}");
+            Logger.DebugIf(LogPrefix,$"ShowDownloadFromUrlDialog called for game: {game.Name}");
 
             // Check if yt-dlp is configured
             var ytDlpPath = _settingsService.Current?.YtDlpPath;
@@ -1373,11 +1363,11 @@ namespace UniPlaySong.Services
 
             if (result == true)
             {
-                LogDebug($"Download from URL completed successfully for game: {game.Name}");
+                Logger.DebugIf(LogPrefix,$"Download from URL completed successfully for game: {game.Name}");
             }
             else
             {
-                LogDebug($"Download from URL cancelled or failed for game: {game.Name}");
+                Logger.DebugIf(LogPrefix,$"Download from URL cancelled or failed for game: {game.Name}");
             }
         }
 
@@ -1392,7 +1382,7 @@ namespace UniPlaySong.Services
                 return;
             }
 
-            LogDebug($"ShowNormalizeIndividualSongProgress called for game: {game.Name}, file: {selectedFile}");
+            Logger.DebugIf(LogPrefix,$"ShowNormalizeIndividualSongProgress called for game: {game.Name}, file: {selectedFile}");
 
             _errorHandler.Try(
                 () =>
@@ -1433,7 +1423,7 @@ namespace UniPlaySong.Services
                 return;
             }
 
-            LogDebug($"ShowTrimIndividualSongProgress called for game: {game.Name}, file: {selectedFile}");
+            Logger.DebugIf(LogPrefix,$"ShowTrimIndividualSongProgress called for game: {game.Name}, file: {selectedFile}");
 
             _errorHandler.Try(
                 () =>
@@ -1478,7 +1468,7 @@ namespace UniPlaySong.Services
             var settings = _settingsService?.Current;
             if (settings == null || !settings.AutoNormalizeAfterDownload)
             {
-                LogDebug("Auto-normalize is disabled, skipping post-download normalization");
+                Logger.DebugIf(LogPrefix,"Auto-normalize is disabled, skipping post-download normalization");
                 return;
             }
 
@@ -1497,7 +1487,7 @@ namespace UniPlaySong.Services
                 return;
             }
 
-            LogDebug($"Auto-normalizing {downloadedFiles.Count} downloaded file(s)...");
+            Logger.DebugIf(LogPrefix,$"Auto-normalizing {downloadedFiles.Count} downloaded file(s)...");
 
             _errorHandler.Try(
                 () =>
@@ -1554,11 +1544,11 @@ namespace UniPlaySong.Services
                             task.Wait(cts.Token);
 
                             var result = task.Result;
-                            LogDebug($"Auto-normalize complete: {result.SuccessCount} succeeded, {result.FailureCount} failed, {result.SkippedCount} skipped");
+                            Logger.DebugIf(LogPrefix,$"Auto-normalize complete: {result.SuccessCount} succeeded, {result.FailureCount} failed, {result.SkippedCount} skipped");
                         }
                         catch (OperationCanceledException)
                         {
-                            LogDebug("Auto-normalize cancelled by user");
+                            Logger.DebugIf(LogPrefix,"Auto-normalize cancelled by user");
                         }
                         catch (Exception ex)
                         {

--- a/Services/MigrationService.cs
+++ b/Services/MigrationService.cs
@@ -17,14 +17,7 @@ namespace UniPlaySong.Services
     public class MigrationService
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
+        private const string LogPrefix = "Migration";
 
         // Audio file extensions to migrate (excludes metadata files like .json)
         private static readonly string[] AudioExtensions =
@@ -79,7 +72,7 @@ namespace UniPlaySong.Services
 
             if (!Directory.Exists(PlayniteSoundGamesPath))
             {
-                LogDebug($"PlayniteSound games path does not exist: {PlayniteSoundGamesPath}");
+                Logger.DebugIf(LogPrefix,$"PlayniteSound games path does not exist: {PlayniteSoundGamesPath}");
                 return games;
             }
 
@@ -129,7 +122,7 @@ namespace UniPlaySong.Services
 
             if (!Directory.Exists(UniPlaySongGamesPath))
             {
-                LogDebug($"UniPlaySong games path does not exist: {UniPlaySongGamesPath}");
+                Logger.DebugIf(LogPrefix,$"UniPlaySong games path does not exist: {UniPlaySongGamesPath}");
                 return games;
             }
 

--- a/ViewModels/DownloadDialogViewModel.cs
+++ b/ViewModels/DownloadDialogViewModel.cs
@@ -22,17 +22,7 @@ namespace UniPlaySong.ViewModels
     public class DownloadDialogViewModel : ObservableObject
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        /// <summary>
-        /// Logs a debug message only if debug logging is enabled in settings.
-        /// </summary>
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
+        private const string LogPrefix = "DownloadDialog";
 
         private readonly IPlayniteAPI _playniteApi;
         private readonly IDownloadManager _downloadManager;
@@ -326,7 +316,7 @@ namespace UniPlaySong.ViewModels
             // Don't search if keyword is empty (user needs to type something)
             if (string.IsNullOrWhiteSpace(searchKeyword) && !_isSongSelection)
             {
-                LogDebug("PerformSearch called but no search term provided - waiting for user input");
+                Logger.DebugIf(LogPrefix,"PerformSearch called but no search term provided - waiting for user input");
                 return;
             }
             
@@ -388,7 +378,7 @@ namespace UniPlaySong.ViewModels
                 if (_isSongSelection && _album != null)
                 {
                     // Load songs from album
-                    LogDebug($"Loading songs from album: {_album.Name}");
+                    Logger.DebugIf(LogPrefix,$"Loading songs from album: {_album.Name}");
                     var songs = _downloadManager.GetSongsFromAlbum(_album, cancellationToken);
                     results = songs.Select(s => new DownloadItemViewModel
                     {
@@ -397,7 +387,7 @@ namespace UniPlaySong.ViewModels
                         Item = s,
                         Source = s.Source
                     }).ToList();
-                    LogDebug($"Found {results.Count} songs from album");
+                    Logger.DebugIf(LogPrefix,$"Found {results.Count} songs from album");
                 }
                 else
                 {
@@ -415,14 +405,14 @@ namespace UniPlaySong.ViewModels
                         return new ObservableCollection<DownloadItemViewModel>(results);
                     }
                     
-                    LogDebug($"Searching for albums: Game='{gameName}', Source={_source}");
+                    Logger.DebugIf(LogPrefix,$"Searching for albums: Game='{gameName}', Source={_source}");
 
                     // Manual search mode: auto=false means no whitelist filtering
                     var albums = _downloadManager.GetAlbumsForGame(gameName, _source, cancellationToken, auto: false);
 
                     // IEnumerable is never null, but can be empty
                     var albumsList = albums?.ToList() ?? new List<Album>();
-                    LogDebug($"Found {albumsList.Count} albums for '{gameName}' from {_source}");
+                    Logger.DebugIf(LogPrefix,$"Found {albumsList.Count} albums for '{gameName}' from {_source}");
                     
                     results = albumsList.Select(a => new DownloadItemViewModel
                     {
@@ -443,7 +433,7 @@ namespace UniPlaySong.ViewModels
             catch (OperationCanceledException)
             {
                 // Search was cancelled, ignore
-                LogDebug("Search was cancelled");
+                Logger.DebugIf(LogPrefix,"Search was cancelled");
                 results = new List<DownloadItemViewModel>();
             }
             catch (Exception ex)
@@ -497,7 +487,7 @@ namespace UniPlaySong.ViewModels
                 var timeSinceLastRequest = (DateTime.Now - _lastPreviewRequestTime).TotalMilliseconds;
                 if (timeSinceLastRequest < MinPreviewIntervalMs)
                 {
-                    LogDebug($"Preview request rate limited - {MinPreviewIntervalMs - timeSinceLastRequest:F0}ms remaining");
+                    Logger.DebugIf(LogPrefix,$"Preview request rate limited - {MinPreviewIntervalMs - timeSinceLastRequest:F0}ms remaining");
                     return;
                 }
                 _lastPreviewRequestTime = DateTime.Now;
@@ -647,7 +637,7 @@ namespace UniPlaySong.ViewModels
                 {
                     _wasGameMusicPlaying = true;
                     _playbackService.Pause();
-                    LogDebug("Paused game music for preview");
+                    Logger.DebugIf(LogPrefix,"Paused game music for preview");
                 }
                 else
                 {
@@ -656,7 +646,7 @@ namespace UniPlaySong.ViewModels
             }
             catch (Exception ex)
             {
-                LogDebug($"Error pausing game music for preview: {ex.Message}");
+                Logger.DebugIf(LogPrefix,$"Error pausing game music for preview: {ex.Message}");
                 _wasGameMusicPlaying = false;
             }
         }
@@ -672,12 +662,12 @@ namespace UniPlaySong.ViewModels
                 {
                     _playbackService.Resume();
                     _wasGameMusicPlaying = false;
-                    LogDebug("Resumed game music after preview");
+                    Logger.DebugIf(LogPrefix,"Resumed game music after preview");
                 }
             }
             catch (Exception ex)
             {
-                LogDebug($"Error resuming game music after preview: {ex.Message}");
+                Logger.DebugIf(LogPrefix,$"Error resuming game music after preview: {ex.Message}");
                 _wasGameMusicPlaying = false;
             }
         }

--- a/ViewModels/DownloadFromUrlViewModel.cs
+++ b/ViewModels/DownloadFromUrlViewModel.cs
@@ -18,14 +18,7 @@ namespace UniPlaySong.ViewModels
     public class DownloadFromUrlViewModel : System.Collections.Generic.ObservableObject
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
+        private const string LogPrefix = "DownloadFromUrl";
 
         private static readonly Regex YoutubeVideoRegex = new Regex(
             @"(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})",
@@ -234,7 +227,7 @@ namespace UniPlaySong.ViewModels
             }
 
             _extractedVideoId = match.Groups[1].Value;
-            LogDebug($"Extracted YouTube video ID: {_extractedVideoId}");
+            Logger.DebugIf(LogPrefix,$"Extracted YouTube video ID: {_extractedVideoId}");
 
             UpdateOnUIThread(() =>
             {
@@ -263,7 +256,7 @@ namespace UniPlaySong.ViewModels
                         ValidationIconColor = Brushes.LimeGreen;
                         IsValidUrl = true;
                         ShowValidationResult = true;
-                        LogDebug($"Video validated: {VideoTitle}");
+                        Logger.DebugIf(LogPrefix,$"Video validated: {VideoTitle}");
                     }
                     else
                     {
@@ -274,7 +267,7 @@ namespace UniPlaySong.ViewModels
             }
             catch (OperationCanceledException)
             {
-                LogDebug("URL validation cancelled");
+                Logger.DebugIf(LogPrefix,"URL validation cancelled");
                 UpdateOnUIThread(() => ShowProgress = false);
             }
             catch (Exception ex)
@@ -475,7 +468,7 @@ namespace UniPlaySong.ViewModels
             }
             catch (OperationCanceledException)
             {
-                LogDebug("Preview download cancelled");
+                Logger.DebugIf(LogPrefix,"Preview download cancelled");
                 UpdateOnUIThread(() => ShowProgress = false);
             }
             catch (Exception ex)
@@ -611,13 +604,13 @@ namespace UniPlaySong.ViewModels
                     {
                         if (_playbackService != null && _settingsService?.Current != null)
                         {
-                            LogDebug($"Force reloading music for game: {_game.Name}");
+                            Logger.DebugIf(LogPrefix,$"Force reloading music for game: {_game.Name}");
                             _playbackService.PlayGameMusic(_game, _settingsService.Current, forceReload: true);
                         }
                     }
                     catch (Exception ex)
                     {
-                        LogDebug($"Error reloading music after download: {ex.Message}");
+                        Logger.DebugIf(LogPrefix,$"Error reloading music after download: {ex.Message}");
                     }
 
                     await Task.Delay(1500);
@@ -635,7 +628,7 @@ namespace UniPlaySong.ViewModels
             }
             catch (OperationCanceledException)
             {
-                LogDebug("Download cancelled");
+                Logger.DebugIf(LogPrefix,"Download cancelled");
                 ProgressText = "Download cancelled.";
             }
             catch (Exception ex)

--- a/Views/ControllerAmplifyDialog.xaml.cs
+++ b/Views/ControllerAmplifyDialog.xaml.cs
@@ -21,14 +21,7 @@ namespace UniPlaySong.Views
     public partial class ControllerAmplifyDialog : UserControl
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug($"[Amplify:Controller] {message}");
-            }
-        }
+        private const string LogPrefix = "Amplify:Controller";
 
         // Controller monitoring
         private CancellationTokenSource _controllerMonitoringCancellation;
@@ -110,7 +103,7 @@ namespace UniPlaySong.Views
                 _amplifyService = amplifyService;
                 _getSettings = getSettings;
 
-                LogDebug($"Initialized controller amplify dialog for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix,$"Initialized controller amplify dialog for game: {game?.Name}");
 
                 ShowFileSelectionStep();
                 LoadMusicFiles();
@@ -509,7 +502,7 @@ namespace UniPlaySong.Views
             {
                 _currentGainDb = newGain;
                 UpdateGainDisplay();
-                LogDebug($"Gain adjusted to {_currentGainDb:+0.0;-0.0;0}dB");
+                Logger.DebugIf(LogPrefix,$"Gain adjusted to {_currentGainDb:+0.0;-0.0;0}dB");
             }
         }
 
@@ -533,7 +526,7 @@ namespace UniPlaySong.Views
             _controllerMonitoringCancellation = new CancellationTokenSource();
 
             _ = Task.Run(() => CheckButtonPresses(_controllerMonitoringCancellation.Token));
-            LogDebug("Started controller monitoring for amplify dialog");
+            Logger.DebugIf(LogPrefix,"Started controller monitoring for amplify dialog");
         }
 
         private void StopControllerMonitoring()
@@ -542,7 +535,7 @@ namespace UniPlaySong.Views
 
             _isMonitoring = false;
             _controllerMonitoringCancellation?.Cancel();
-            LogDebug("Stopped controller monitoring for amplify dialog");
+            Logger.DebugIf(LogPrefix,"Stopped controller monitoring for amplify dialog");
         }
 
         private async Task CheckButtonPresses(CancellationToken cancellationToken)
@@ -587,7 +580,7 @@ namespace UniPlaySong.Views
                 }
                 catch (Exception ex)
                 {
-                    LogDebug($"Error in controller monitoring: {ex.Message}");
+                    Logger.DebugIf(LogPrefix,$"Error in controller monitoring: {ex.Message}");
                     await Task.Delay(100, cancellationToken);
                 }
             }
@@ -843,7 +836,7 @@ namespace UniPlaySong.Views
 
             try
             {
-                LogDebug($"Preview with gain: {_currentGainDb:+0.0;-0.0;0}dB");
+                Logger.DebugIf(LogPrefix,$"Preview with gain: {_currentGainDb:+0.0;-0.0;0}dB");
 
                 // Get user's configured volume setting (0-100) and convert to 0-1 range
                 var settings = _getSettings?.Invoke();
@@ -863,7 +856,7 @@ namespace UniPlaySong.Views
                 // Use the same SDL2 backend for preview (consistent volume with normal playback)
                 _playbackService?.PlayPreview(_waveformData.FilePath, clampedVolume);
 
-                LogDebug($"Preview at volume {clampedVolume:F2} (user: {userVolume:F2} x gain: {gainMultiplier:F2})");
+                Logger.DebugIf(LogPrefix,$"Preview at volume {clampedVolume:F2} (user: {userVolume:F2} x gain: {gainMultiplier:F2})");
 
                 if (wasCapped)
                 {
@@ -887,7 +880,7 @@ namespace UniPlaySong.Views
 
             var fileName = Path.GetFileName(_selectedFilePath);
 
-            LogDebug($"ApplyButton_Click: file={fileName}, gain={_currentGainDb:+0.0;-0.0;0}dB");
+            Logger.DebugIf(LogPrefix,$"ApplyButton_Click: file={fileName}, gain={_currentGainDb:+0.0;-0.0;0}dB");
 
             var clippingWarning = "";
             if (_waveformData.WouldClip(_currentGainDb))

--- a/Views/ControllerDeleteSongsDialog.xaml.cs
+++ b/Views/ControllerDeleteSongsDialog.xaml.cs
@@ -20,28 +20,7 @@ namespace UniPlaySong.Views
     public partial class ControllerDeleteSongsDialog : UserControl
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        /// <summary>
-        /// Logs a debug message only if debug logging is enabled in settings.
-        /// </summary>
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
-
-        /// <summary>
-        /// Logs a debug message with exception only if debug logging is enabled.
-        /// </summary>
-        private static void LogDebug(Exception ex, string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(ex, message);
-            }
-        }
+        private const string LogPrefix = "DeleteSongs";
 
         // Controller monitoring
         private CancellationTokenSource _controllerMonitoringCancellation;
@@ -102,7 +81,7 @@ namespace UniPlaySong.Views
                 _fileService = fileService;
                 _playbackService = playbackService;
 
-                LogDebug($"Initialized delete songs dialog for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix, $"Initialized delete songs dialog for game: {game?.Name}");
 
                 // Load music files
                 LoadMusicFiles();
@@ -243,7 +222,7 @@ namespace UniPlaySong.Views
                 }
                 catch (Exception ex)
                 {
-                    LogDebug(ex, $"Error getting file size for {filePath}");
+                    Logger.DebugIf(LogPrefix, ex, $"Error getting file size for {filePath}");
                 }
 
                 listItem.Content = stackPanel;
@@ -319,7 +298,7 @@ namespace UniPlaySong.Views
             _controllerMonitoringCancellation = new CancellationTokenSource();
             
             _ = Task.Run(() => CheckButtonPresses(_controllerMonitoringCancellation.Token));
-            LogDebug("Started controller monitoring for delete songs dialog");
+            Logger.DebugIf(LogPrefix, "Started controller monitoring for delete songs dialog");
         }
 
         /// <summary>
@@ -331,7 +310,7 @@ namespace UniPlaySong.Views
 
             _isMonitoring = false;
             _controllerMonitoringCancellation?.Cancel();
-            LogDebug("Stopped controller monitoring for delete songs dialog");
+            Logger.DebugIf(LogPrefix, "Stopped controller monitoring for delete songs dialog");
         }
 
         /// <summary>
@@ -370,7 +349,7 @@ namespace UniPlaySong.Views
                 }
                 catch (Exception ex)
                 {
-                    LogDebug(ex, "Error in controller monitoring");
+                    Logger.DebugIf(LogPrefix, ex, "Error in controller monitoring");
                     await Task.Delay(100, cancellationToken);
                 }
             }
@@ -568,7 +547,7 @@ namespace UniPlaySong.Views
                 _previewPlayer.Play();
                 
                 UpdateInputFeedback($"🔊 Playing preview: {fileName} - X/Y to stop (Game music paused)");
-                LogDebug($"Started preview for: {fileName}");
+                Logger.DebugIf(LogPrefix, $"Started preview for: {fileName}");
             }
             catch (Exception ex)
             {
@@ -612,7 +591,7 @@ namespace UniPlaySong.Views
                 {
                     _wasGameMusicPlaying = true;
                     _playbackService.Pause();
-                    LogDebug("Paused game music for preview");
+                    Logger.DebugIf(LogPrefix, "Paused game music for preview");
                 }
                 else
                 {
@@ -637,7 +616,7 @@ namespace UniPlaySong.Views
                 {
                     _playbackService.Resume();
                     _wasGameMusicPlaying = false;
-                    LogDebug("Resumed game music after preview");
+                    Logger.DebugIf(LogPrefix, "Resumed game music after preview");
                 }
             }
             catch (Exception ex)
@@ -764,7 +743,7 @@ namespace UniPlaySong.Views
                 
                 message += "\n\nThis action cannot be undone!";
 
-                LogDebug($"Showing confirmation dialog for: {fileName}");
+                Logger.DebugIf(LogPrefix, $"Showing confirmation dialog for: {fileName}");
 
                 // Show confirmation dialog
                 var result = _playniteApi?.Dialogs?.ShowMessage(
@@ -776,7 +755,7 @@ namespace UniPlaySong.Views
                 // Clear confirmation flag immediately after dialog closes
                 _isShowingConfirmation = false;
                 
-                LogDebug($"Confirmation result: {result}");
+                Logger.DebugIf(LogPrefix, $"Confirmation result: {result}");
 
                 if (result == MessageBoxResult.Yes)
                 {
@@ -814,7 +793,7 @@ namespace UniPlaySong.Views
         {
             try
             {
-                LogDebug($"Stopping all music playback before deleting: {fileName}");
+                Logger.DebugIf(LogPrefix, $"Stopping all music playback before deleting: {fileName}");
                 
                 // Stop any preview that might be playing
                 StopCurrentPreview();
@@ -825,7 +804,7 @@ namespace UniPlaySong.Views
                     if (_playbackService.IsPlaying)
                     {
                         _playbackService.Stop();
-                        LogDebug("Stopped game music playback for file deletion");
+                        Logger.DebugIf(LogPrefix, "Stopped game music playback for file deletion");
                         
                         // Give a moment for the file to be released
                         System.Threading.Thread.Sleep(100);
@@ -867,7 +846,7 @@ namespace UniPlaySong.Views
                 if (_currentlyPreviewing == filePath)
                 {
                     StopCurrentPreview();
-                    LogDebug("Stopped preview for file being deleted");
+                    Logger.DebugIf(LogPrefix, "Stopped preview for file being deleted");
                 }
 
                 // Clear primary song if this is the primary
@@ -881,7 +860,7 @@ namespace UniPlaySong.Views
                 System.Threading.Thread.Sleep(200);
                 
                 // Delete the file
-                LogDebug($"Attempting to delete file: {filePath}");
+                Logger.DebugIf(LogPrefix, $"Attempting to delete file: {filePath}");
                 File.Delete(filePath);
                 Logger.Info($"File deleted successfully: {filePath}");
                 
@@ -893,7 +872,7 @@ namespace UniPlaySong.Views
                 
                 // Remove from our list
                 _musicFiles.Remove(filePath);
-                LogDebug($"Removed from music files list: {fileName}");
+                Logger.DebugIf(LogPrefix, $"Removed from music files list: {fileName}");
                 
                 // Update UI
                 PopulateFilesList();
@@ -945,7 +924,7 @@ namespace UniPlaySong.Views
             {
                 // Always reset deletion state
                 ResetDeletionState();
-                LogDebug("Deletion process completed, state reset");
+                Logger.DebugIf(LogPrefix, "Deletion process completed, state reset");
             }
         }
 
@@ -978,7 +957,7 @@ namespace UniPlaySong.Views
                     }
                     catch (Exception focusEx)
                     {
-                        LogDebug(focusEx, "Error returning focus to main window");
+                        Logger.DebugIf(LogPrefix, focusEx, "Error returning focus to main window");
                     }
                     
                     window.DialogResult = success;

--- a/Views/ControllerFilePickerDialog.xaml.cs
+++ b/Views/ControllerFilePickerDialog.xaml.cs
@@ -20,28 +20,7 @@ namespace UniPlaySong.Views
     public partial class ControllerFilePickerDialog : UserControl
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        /// <summary>
-        /// Logs a debug message only if debug logging is enabled in settings.
-        /// </summary>
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
-
-        /// <summary>
-        /// Logs a debug message with exception only if debug logging is enabled.
-        /// </summary>
-        private static void LogDebug(Exception ex, string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(ex, message);
-            }
-        }
+        private const string LogPrefix = "FilePicker";
 
         // Controller monitoring
         private CancellationTokenSource _controllerMonitoringCancellation;
@@ -110,7 +89,7 @@ namespace UniPlaySong.Views
                 _playbackService = playbackService;
                 _mode = mode;
 
-                LogDebug($"Initialized file picker for game: {game?.Name}, mode: {mode}");
+                Logger.DebugIf(LogPrefix, $"Initialized file picker for game: {game?.Name}, mode: {mode}");
 
                 // Update UI based on mode
                 UpdateUIForMode();
@@ -344,7 +323,7 @@ namespace UniPlaySong.Views
             _controllerMonitoringCancellation = new CancellationTokenSource();
             
             _ = Task.Run(() => CheckButtonPresses(_controllerMonitoringCancellation.Token));
-            LogDebug("Started controller monitoring for file picker");
+            Logger.DebugIf(LogPrefix, "Started controller monitoring for file picker");
         }
 
         /// <summary>
@@ -356,7 +335,7 @@ namespace UniPlaySong.Views
 
             _isMonitoring = false;
             _controllerMonitoringCancellation?.Cancel();
-            LogDebug("Stopped controller monitoring for file picker");
+            Logger.DebugIf(LogPrefix, "Stopped controller monitoring for file picker");
         }
 
         /// <summary>
@@ -395,7 +374,7 @@ namespace UniPlaySong.Views
                 }
                 catch (Exception ex)
                 {
-                    LogDebug(ex, "Error in controller monitoring");
+                    Logger.DebugIf(LogPrefix, ex, "Error in controller monitoring");
                     await Task.Delay(100, cancellationToken);
                 }
             }
@@ -587,7 +566,7 @@ namespace UniPlaySong.Views
                 _previewPlayer.Play();
                 
                 UpdateInputFeedback($"🔊 Playing preview: {fileName} - X/Y to stop (Game music paused)");
-                LogDebug($"Started preview for: {fileName}");
+                Logger.DebugIf(LogPrefix, $"Started preview for: {fileName}");
             }
             catch (Exception ex)
             {
@@ -631,7 +610,7 @@ namespace UniPlaySong.Views
                 {
                     _wasGameMusicPlaying = true;
                     _playbackService.Pause();
-                    LogDebug("Paused game music for preview");
+                    Logger.DebugIf(LogPrefix, "Paused game music for preview");
                 }
                 else
                 {
@@ -656,7 +635,7 @@ namespace UniPlaySong.Views
                 {
                     _playbackService.Resume();
                     _wasGameMusicPlaying = false;
-                    LogDebug("Resumed game music after preview");
+                    Logger.DebugIf(LogPrefix, "Resumed game music after preview");
                 }
             }
             catch (Exception ex)
@@ -943,7 +922,7 @@ namespace UniPlaySong.Views
                     }
                     catch (Exception focusEx)
                     {
-                        LogDebug(focusEx, "Error returning focus to main window");
+                        Logger.DebugIf(LogPrefix, focusEx, "Error returning focus to main window");
                     }
                     
                     window.DialogResult = success;

--- a/Views/ControllerWaveformTrimDialog.xaml.cs
+++ b/Views/ControllerWaveformTrimDialog.xaml.cs
@@ -24,14 +24,7 @@ namespace UniPlaySong.Views
     public partial class ControllerWaveformTrimDialog : UserControl
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug($"[PreciseTrim:Controller] {message}");
-            }
-        }
+        private const string LogPrefix = "PreciseTrim:Controller";
 
         // Controller monitoring
         private CancellationTokenSource _controllerMonitoringCancellation;
@@ -116,7 +109,7 @@ namespace UniPlaySong.Views
                 _waveformTrimService = waveformTrimService;
                 _getSettings = getSettings;
 
-                LogDebug($"Initialized controller waveform trim for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix,$"Initialized controller waveform trim for game: {game?.Name}");
 
                 // Start at file selection
                 ShowFileSelectionStep();
@@ -461,7 +454,7 @@ namespace UniPlaySong.Views
             _controllerMonitoringCancellation = new CancellationTokenSource();
 
             _ = Task.Run(() => CheckButtonPresses(_controllerMonitoringCancellation.Token));
-            LogDebug("Started controller monitoring for waveform trim dialog");
+            Logger.DebugIf(LogPrefix,"Started controller monitoring for waveform trim dialog");
         }
 
         private void StopControllerMonitoring()
@@ -470,7 +463,7 @@ namespace UniPlaySong.Views
 
             _isMonitoring = false;
             _controllerMonitoringCancellation?.Cancel();
-            LogDebug("Stopped controller monitoring for waveform trim dialog");
+            Logger.DebugIf(LogPrefix,"Stopped controller monitoring for waveform trim dialog");
         }
 
         private async Task CheckButtonPresses(CancellationToken cancellationToken)
@@ -519,7 +512,7 @@ namespace UniPlaySong.Views
                 }
                 catch (Exception ex)
                 {
-                    LogDebug($"Error in controller monitoring: {ex.Message}");
+                    Logger.DebugIf(LogPrefix,$"Error in controller monitoring: {ex.Message}");
                     await Task.Delay(100, cancellationToken);
                 }
             }
@@ -782,7 +775,7 @@ namespace UniPlaySong.Views
                 StopPreview();
 
                 // Load and play the file from the start marker position
-                LogDebug($"Starting preview from {_trimWindow.StartTime:mm\\:ss\\.fff}");
+                Logger.DebugIf(LogPrefix,$"Starting preview from {_trimWindow.StartTime:mm\\:ss\\.fff}");
                 _playbackService.LoadAndPlayFileFrom(_selectedFilePath, _trimWindow.StartTime);
 
                 _isPreviewing = true;
@@ -898,7 +891,7 @@ namespace UniPlaySong.Views
                 ApplyTrimButton.IsEnabled = false;
 
                 // Pass FFmpeg path directly instead of relying on reflection
-                LogDebug($"Applying trim with FFmpeg path: {ffmpegPath}");
+                Logger.DebugIf(LogPrefix,$"Applying trim with FFmpeg path: {ffmpegPath}");
                 var success = await _waveformTrimService.ApplyTrimAsync(
                     _selectedFilePath, _trimWindow, suffix, ffmpegPath, CancellationToken.None);
 
@@ -1056,7 +1049,7 @@ namespace UniPlaySong.Views
                     }
                     catch (Exception focusEx)
                     {
-                        LogDebug($"Error returning focus: {focusEx.Message}");
+                        Logger.DebugIf(LogPrefix,$"Error returning focus: {focusEx.Message}");
                     }
 
                     window.DialogResult = success;

--- a/Views/SimpleControllerDialog.xaml.cs
+++ b/Views/SimpleControllerDialog.xaml.cs
@@ -23,28 +23,7 @@ namespace UniPlaySong.Views
     public partial class SimpleControllerDialog : UserControl
     {
         private static readonly ILogger Logger = LogManager.GetLogger();
-
-        /// <summary>
-        /// Logs a debug message only if debug logging is enabled in settings.
-        /// </summary>
-        private static void LogDebug(string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(message);
-            }
-        }
-
-        /// <summary>
-        /// Logs a debug message with exception only if debug logging is enabled.
-        /// </summary>
-        private static void LogDebug(Exception ex, string message)
-        {
-            if (FileLogger.IsDebugLoggingEnabled)
-            {
-                Logger.Debug(ex, message);
-            }
-        }
+        private const string LogPrefix = "ControllerDownload";
 
         private CancellationTokenSource _controllerMonitoringCancellation;
         private bool _isMonitoring = false;
@@ -88,7 +67,7 @@ namespace UniPlaySong.Views
         public SimpleControllerDialog()
         {
             InitializeComponent();
-            LogDebug("Controller download dialog initialized");
+            Logger.DebugIf(LogPrefix, "Controller download dialog initialized");
             
             // Focus the first item for controller navigation
             Loaded += (s, e) => 
@@ -128,7 +107,7 @@ namespace UniPlaySong.Views
                 _fileService = fileService;
                 _currentStep = DialogStep.SourceSelection;
                 
-                LogDebug($"Initialized controller dialog for game: {game?.Name}");
+                Logger.DebugIf(LogPrefix, $"Initialized controller dialog for game: {game?.Name}");
                 
                 // Load source selection
                 LoadSourceSelection();
@@ -165,7 +144,7 @@ namespace UniPlaySong.Views
                 UpdateUIForSourceSelection();
                 PopulateResultsList(_sourceOptions.Select(CreateSourceItem).ToList());
                 
-                LogDebug("Loaded source selection options");
+                Logger.DebugIf(LogPrefix, "Loaded source selection options");
             }
             catch (Exception ex)
             {
@@ -187,7 +166,7 @@ namespace UniPlaySong.Views
             }
             catch (Exception ex)
             {
-                LogDebug(ex, "Error checking YouTube configuration");
+                Logger.DebugIf(LogPrefix, ex, "Error checking YouTube configuration");
                 return false;
             }
         }
@@ -334,35 +313,35 @@ namespace UniPlaySong.Views
         {
             try
             {
-                LogDebug($"HandleCancelAction called - Current step: {_currentStep}");
+                Logger.DebugIf(LogPrefix, $"HandleCancelAction called - Current step: {_currentStep}");
                 
                 switch (_currentStep)
                 {
                     case DialogStep.SourceSelection:
                         // Close the dialog
-                        LogDebug("Closing controller dialog from source selection");
+                        Logger.DebugIf(LogPrefix, "Closing controller dialog from source selection");
                         CloseDialog(false);
                         break;
                         
                     case DialogStep.AlbumSelection:
                         // Go back to source selection
-                        LogDebug("Going back to source selection from album selection");
+                        Logger.DebugIf(LogPrefix, "Going back to source selection from album selection");
                         LoadSourceSelection();
                         break;
                         
                     case DialogStep.SongSelection:
                         // Go back to album selection
-                        LogDebug($"Going back to album selection from song selection - Selected source: {_selectedSource}");
+                        Logger.DebugIf(LogPrefix, $"Going back to album selection from song selection - Selected source: {_selectedSource}");
                         try
                         {
                             if (_selectedSource.HasValue)
                             {
-                                LogDebug($"Loading album selection for source: {_selectedSource.Value}");
+                                Logger.DebugIf(LogPrefix, $"Loading album selection for source: {_selectedSource.Value}");
                                 LoadAlbumSelection(_selectedSource.Value);
                             }
                             else
                             {
-                                LogDebug("No selected source, going back to source selection");
+                                Logger.DebugIf(LogPrefix, "No selected source, going back to source selection");
                                 LoadSourceSelection();
                             }
                         }
@@ -376,13 +355,13 @@ namespace UniPlaySong.Views
                         
                     case DialogStep.Downloading:
                         // Cancel download
-                        LogDebug("Cancelling download");
+                        Logger.DebugIf(LogPrefix, "Cancelling download");
                         UpdateInputFeedback("❌ Download cancelled");
                         CloseDialog(false);
                         break;
                         
                     default:
-                        LogDebug($"Unknown step {_currentStep}, closing dialog");
+                        Logger.DebugIf(LogPrefix, $"Unknown step {_currentStep}, closing dialog");
                         CloseDialog(false);
                         break;
                 }
@@ -402,7 +381,7 @@ namespace UniPlaySong.Views
         {
             try
             {
-                LogDebug($"CloseDialog called with success: {success}");
+                Logger.DebugIf(LogPrefix, $"CloseDialog called with success: {success}");
                 
                 // Stop any preview playback and restore game music
                 StopCurrentPreview();
@@ -410,7 +389,7 @@ namespace UniPlaySong.Views
                 var window = Window.GetWindow(this);
                 if (window != null)
                 {
-                    LogDebug("Closing dialog window");
+                    Logger.DebugIf(LogPrefix, "Closing dialog window");
                     
                     // Force focus return to Playnite main window
                     try
@@ -418,7 +397,7 @@ namespace UniPlaySong.Views
                         var mainWindow = _playniteApi?.Dialogs?.GetCurrentAppWindow();
                         if (mainWindow != null)
                         {
-                            LogDebug("Forcing focus return to main window");
+                            Logger.DebugIf(LogPrefix, "Forcing focus return to main window");
                             
                             // Multiple attempts to ensure focus returns
                             mainWindow.Activate();
@@ -437,7 +416,7 @@ namespace UniPlaySong.Views
                                     }
                                     catch (Exception delayedFocusEx)
                                     {
-                                        LogDebug(delayedFocusEx, "Error in delayed focus return");
+                                        Logger.DebugIf(LogPrefix, delayedFocusEx, "Error in delayed focus return");
                                     }
                                 }));
                             });
@@ -445,7 +424,7 @@ namespace UniPlaySong.Views
                     }
                     catch (Exception focusEx)
                     {
-                        LogDebug(focusEx, "Error returning focus to main window");
+                        Logger.DebugIf(LogPrefix, focusEx, "Error returning focus to main window");
                     }
                     
                     window.DialogResult = success;
@@ -453,7 +432,7 @@ namespace UniPlaySong.Views
                 }
                 else
                 {
-                    LogDebug("No parent window found to close");
+                    Logger.DebugIf(LogPrefix, "No parent window found to close");
                 }
             }
             catch (Exception ex)
@@ -545,7 +524,7 @@ namespace UniPlaySong.Views
                     }));
                 });
                 
-                LogDebug($"Previewed source: {sourceOption.Name}");
+                Logger.DebugIf(LogPrefix, $"Previewed source: {sourceOption.Name}");
             }
             catch (Exception ex)
             {
@@ -588,7 +567,7 @@ namespace UniPlaySong.Views
                     }));
                 });
                 
-                LogDebug($"Previewed album: {album.Name}");
+                Logger.DebugIf(LogPrefix, $"Previewed album: {album.Name}");
             }
             catch (Exception ex)
             {
@@ -618,7 +597,7 @@ namespace UniPlaySong.Views
                 if (timeSinceLastRequest < MinPreviewIntervalMs)
                 {
                     var remainingMs = MinPreviewIntervalMs - timeSinceLastRequest;
-                    LogDebug($"Preview request rate limited - {remainingMs:F0}ms remaining");
+                    Logger.DebugIf(LogPrefix, $"Preview request rate limited - {remainingMs:F0}ms remaining");
                     UpdateInputFeedback($"⏳ Please wait {remainingMs / 1000.0:F1}s before previewing again");
                     return;
                 }
@@ -656,12 +635,12 @@ namespace UniPlaySong.Views
                                 UpdateInputFeedback($"⬇️ Downloading preview: {song.Name}...");
                             }));
                             
-                            LogDebug($"Preview file doesn't exist, downloading to: {tempPath}");
+                            Logger.DebugIf(LogPrefix, $"Preview file doesn't exist, downloading to: {tempPath}");
                             
                             var cancellationToken = new CancellationTokenSource().Token;
                             var downloaded = _downloadManager?.DownloadSong(song, tempPath, cancellationToken, isPreview: true) ?? false;
                             
-                            LogDebug($"Download result: {downloaded}, File exists after download: {System.IO.File.Exists(tempPath)}");
+                            Logger.DebugIf(LogPrefix, $"Download result: {downloaded}, File exists after download: {System.IO.File.Exists(tempPath)}");
                             
                             if (!downloaded || !System.IO.File.Exists(tempPath))
                             {
@@ -673,11 +652,11 @@ namespace UniPlaySong.Views
                                 return;
                             }
                             
-                            LogDebug($"Preview download successful, file size: {new System.IO.FileInfo(tempPath).Length} bytes");
+                            Logger.DebugIf(LogPrefix, $"Preview download successful, file size: {new System.IO.FileInfo(tempPath).Length} bytes");
                         }
                         else
                         {
-                            LogDebug($"Preview file already exists: {tempPath}");
+                            Logger.DebugIf(LogPrefix, $"Preview file already exists: {tempPath}");
                         }
 
                         // Play the preview on the UI thread
@@ -687,7 +666,7 @@ namespace UniPlaySong.Views
                             UpdateInputFeedback($"🔊 Playing preview: {song.Name} - X/Y to stop (Game music paused)");
                         }));
                         
-                        LogDebug($"Started audio preview for song: {song.Name}");
+                        Logger.DebugIf(LogPrefix, $"Started audio preview for song: {song.Name}");
                     }
                     catch (Exception ex)
                     {
@@ -725,7 +704,7 @@ namespace UniPlaySong.Views
                     _previewPlayer.Stop();
                     _previewPlayer.Close();
                     _previewPlayer = null;
-                    LogDebug("Stopped preview player");
+                    Logger.DebugIf(LogPrefix, "Stopped preview player");
                 }
 
                 _currentlyPreviewing = null;
@@ -750,7 +729,7 @@ namespace UniPlaySong.Views
                 {
                     _wasGameMusicPlaying = true;
                     _playbackService.Pause();
-                    LogDebug("Paused game music for preview");
+                    Logger.DebugIf(LogPrefix, "Paused game music for preview");
                 }
                 else
                 {
@@ -775,7 +754,7 @@ namespace UniPlaySong.Views
                 {
                     _playbackService.Resume();
                     _wasGameMusicPlaying = false;
-                    LogDebug("Resumed game music after preview");
+                    Logger.DebugIf(LogPrefix, "Resumed game music after preview");
                 }
             }
             catch (Exception ex)
@@ -792,7 +771,7 @@ namespace UniPlaySong.Views
         {
             try
             {
-                LogDebug($"PlayPreviewFile called for: {songName}, path: {tempPath}");
+                Logger.DebugIf(LogPrefix, $"PlayPreviewFile called for: {songName}, path: {tempPath}");
                 
                 if (!System.IO.File.Exists(tempPath))
                 {
@@ -813,7 +792,7 @@ namespace UniPlaySong.Views
                 
                 _previewPlayer.MediaEnded += (s, e) => 
                 {
-                    LogDebug("Preview MediaEnded event fired");
+                    Logger.DebugIf(LogPrefix, "Preview MediaEnded event fired");
                     Dispatcher.BeginInvoke(new Action(() =>
                     {
                         UpdateInputFeedback("🎮 Preview ended - Game music resumed - X/Y to play again");
@@ -834,7 +813,7 @@ namespace UniPlaySong.Views
                 _previewPlayer.Open(new Uri(tempPath));
                 _previewPlayer.Play();
                 
-                LogDebug($"Preview started for: {songName}");
+                Logger.DebugIf(LogPrefix, $"Preview started for: {songName}");
             }
             catch (Exception ex)
             {
@@ -917,7 +896,7 @@ namespace UniPlaySong.Views
                         break;
                         
                     default:
-                        LogDebug($"Unhandled dialog step: {_currentStep}");
+                        Logger.DebugIf(LogPrefix, $"Unhandled dialog step: {_currentStep}");
                         break;
                 }
             }
@@ -983,13 +962,13 @@ namespace UniPlaySong.Views
                         var cancellationToken = new CancellationTokenSource().Token;
                         var gameName = _currentGame?.Name ?? "Unknown Game";
                         
-                        LogDebug($"Searching for albums: Game='{gameName}', Source={source}");
+                        Logger.DebugIf(LogPrefix, $"Searching for albums: Game='{gameName}', Source={source}");
                         
                         // Search for real albums using the download manager
                         var albums = _downloadManager?.GetAlbumsForGame(gameName, source, cancellationToken, auto: false);
                         var albumsList = albums?.ToList() ?? new List<Album>();
                         
-                        LogDebug($"Found {albumsList.Count} albums for '{gameName}' from {source}");
+                        Logger.DebugIf(LogPrefix, $"Found {albumsList.Count} albums for '{gameName}' from {source}");
                         
                         // Convert to view models
                         var albumViewModels = albumsList.Select(a => new DownloadItemViewModel
@@ -1113,13 +1092,13 @@ namespace UniPlaySong.Views
                     {
                         var cancellationToken = new CancellationTokenSource().Token;
                         
-                        LogDebug($"Loading songs from album: {album.Name}");
+                        Logger.DebugIf(LogPrefix, $"Loading songs from album: {album.Name}");
                         
                         // Load real songs using the download manager
                         var songs = _downloadManager?.GetSongsFromAlbum(album, cancellationToken);
                         var songsList = songs?.ToList() ?? new List<Song>();
                         
-                        LogDebug($"Found {songsList.Count} songs from album '{album.Name}'");
+                        Logger.DebugIf(LogPrefix, $"Found {songsList.Count} songs from album '{album.Name}'");
                         
                         // Convert to view models
                         var songViewModels = songsList.Select(s => new DownloadItemViewModel
@@ -1222,7 +1201,7 @@ namespace UniPlaySong.Views
                 {
                     try
                     {
-                        LogDebug($"Starting download for song: {selectedSong.Name}");
+                        Logger.DebugIf(LogPrefix, $"Starting download for song: {selectedSong.Name}");
                         
                         // Use the same path logic as regular dialog
                         var musicDir = _fileService.GetGameMusicDirectory(_currentGame);
@@ -1251,7 +1230,7 @@ namespace UniPlaySong.Views
                                 if (success && System.IO.File.Exists(filePath))
                                 {
                                     UpdateInputFeedback($"✅ Download completed: {selectedSong.Name}");
-                                    LogDebug($"Successfully downloaded: {selectedSong.Name} to {filePath}");
+                                    Logger.DebugIf(LogPrefix, $"Successfully downloaded: {selectedSong.Name} to {filePath}");
 
                                     // Show success message first (blocking dialog)
                                     _playniteApi?.Dialogs?.ShowMessage(
@@ -1269,7 +1248,7 @@ namespace UniPlaySong.Views
                                     }
                                     catch (Exception normalizeEx)
                                     {
-                                        LogDebug(normalizeEx, "Error during auto-normalize after download");
+                                        Logger.DebugIf(LogPrefix, normalizeEx, "Error during auto-normalize after download");
                                     }
 
                                     // Trigger music refresh so music plays immediately after download/normalize
@@ -1277,7 +1256,7 @@ namespace UniPlaySong.Views
                                     {
                                         if (_playbackService != null && _currentGame != null)
                                         {
-                                            LogDebug($"Download complete - triggering music refresh for game: {_currentGame.Name}");
+                                            Logger.DebugIf(LogPrefix, $"Download complete - triggering music refresh for game: {_currentGame.Name}");
                                             // Use forceReload: true to ensure newly downloaded song plays
                                             // Pass null settings - playback service uses its cached _currentSettings
                                             _playbackService.PlayGameMusic(_currentGame, null, forceReload: true);
@@ -1285,7 +1264,7 @@ namespace UniPlaySong.Views
                                     }
                                     catch (Exception refreshEx)
                                     {
-                                        LogDebug(refreshEx, "Error refreshing music after download");
+                                        Logger.DebugIf(LogPrefix, refreshEx, "Error refreshing music after download");
                                     }
                                 }
                                 else
@@ -1323,7 +1302,7 @@ namespace UniPlaySong.Views
                     }
                 });
                 
-                LogDebug($"Initiated download for song: {selectedSong.Name}");
+                Logger.DebugIf(LogPrefix, $"Initiated download for song: {selectedSong.Name}");
             }
             catch (Exception ex)
             {
@@ -1399,7 +1378,7 @@ namespace UniPlaySong.Views
                 // Update feedback text to show input was received
                 UpdateInputFeedback($"Last input: {e.Key} ✓");
                 
-                LogDebug($"Controller input: {e.Key}");
+                Logger.DebugIf(LogPrefix, $"Controller input: {e.Key}");
             }
             catch (Exception ex)
             {
@@ -1509,7 +1488,7 @@ namespace UniPlaySong.Views
                 
                 Task.Run(async () =>
                 {
-                    LogDebug("Starting Xbox controller monitoring");
+                    Logger.DebugIf(LogPrefix, "Starting Xbox controller monitoring");
                     
                     while (!_controllerMonitoringCancellation.Token.IsCancellationRequested)
                     {
@@ -1539,12 +1518,12 @@ namespace UniPlaySong.Views
                         }
                         catch (Exception ex)
                         {
-                            LogDebug(ex, "Error in controller monitoring loop");
+                            Logger.DebugIf(LogPrefix, ex, "Error in controller monitoring loop");
                             await Task.Delay(1000, _controllerMonitoringCancellation.Token); // Wait longer on error
                         }
                     }
                     
-                    LogDebug("Xbox controller monitoring stopped");
+                    Logger.DebugIf(LogPrefix, "Xbox controller monitoring stopped");
                 }, _controllerMonitoringCancellation.Token);
             }
             catch (Exception ex)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a centralized, opt-in debug logging pattern and applies it project-wide.
> 
> - Adds `Common/LoggerExtensions.cs` with `ILogger.DebugIf(prefix, message|ex,message)` to emit debug logs only when enabled
> - Replaces ad-hoc `LogDebug` helpers and direct `Logger.Debug(...)` with `Logger.DebugIf` and per-file `LogPrefix` constants across DownloadManager, KHInsider/YouTube clients and downloaders, dialog handlers, services (amplify, trim, migration, download), and viewmodels/views
> - Normalizes/collapses repetitive debug output and adds consistent cancellation/status logging without changing core logic
> - Cleans up path usage in views by removing `IOPath` alias and using `System.IO.Path` directly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 072d769fc016c11ada22801855daa16743b040ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->