### PR TITLE
Audio Live Effects Advanced Tuning and bug-fixes

### DIFF
--- a/Audio/EffectsChain.cs
+++ b/Audio/EffectsChain.cs
@@ -59,7 +59,7 @@ namespace UniPlaySong.Audio
         // RoomScaleMin/Max: Controls the range of room size scaling.
         //   - Default: 0.1 to 1.0 (maps 0-100% room size slider)
         //   - Affects comb filter delay lengths (perceived room size)
-        private const float DefaultWetGainMultiplier = 0.08f;
+        private const float DefaultWetGainMultiplier = 0.03f;
         private const float DefaultAllpassFeedback = 0.5f;
         private const float DefaultHfDampingMin = 0.2f;
         private const float DefaultHfDampingMax = 0.5f;
@@ -302,6 +302,13 @@ namespace UniPlaySong.Audio
             {
                 _preDelaySize = Math.Max(1, (int)(settings.ReverbPreDelay / 1000.0 * _sampleRate));
                 _lastPreDelay = settings.ReverbPreDelay;
+            }
+
+            // Update reverb if room size changed (reinitialize comb/allpass filter buffers)
+            if (_lastRoomSize != settings.ReverbRoomSize)
+            {
+                InitializeReverb(_sampleRate, settings.ReverbRoomSize);
+                _lastRoomSize = settings.ReverbRoomSize;
             }
 
             // Check if any effects are enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,13 @@ All notable changes to UniPlaySong will be documented in this file.
 
 ### Changed
 - Live Effects reverb algorithm now uses Reverberance (not Room Size) for feedback calculation, matching Audacity behavior
-- Reverb wet gain multiplier increased from 0.015 to 0.08 for more pronounced effects
+- Reverb wet gain multiplier changed to 0.03 for balanced reverb intensity (adjustable via Advanced Tuning)
 - Reverb tuning constants extracted and documented in EffectsChain.cs for easy modification
+
+### Fixed
+- Room size slider changes now apply in real-time during playback (previously required song restart)
+- Stop() no longer incorrectly triggers MediaEnded event in NAudio player
+- Music now properly restarts when toggling Live Effects on/off (instead of just stopping)
 
 ## [1.1.3] - 2026-01-02
 

--- a/Services/NAudioMusicPlayer.cs
+++ b/Services/NAudioMusicPlayer.cs
@@ -150,7 +150,14 @@ namespace UniPlaySong.Services
         {
             try
             {
-                _outputDevice?.Stop();
+                if (_outputDevice != null)
+                {
+                    // Remove handler BEFORE stopping to prevent MediaEnded being fired
+                    _outputDevice.PlaybackStopped -= OnPlaybackStopped;
+                    _outputDevice.Stop();
+                    // Re-attach handler for future playback
+                    _outputDevice.PlaybackStopped += OnPlaybackStopped;
+                }
             }
             catch (Exception ex)
             {

--- a/UniPlaySongSettings.cs
+++ b/UniPlaySongSettings.cs
@@ -651,7 +651,7 @@ namespace UniPlaySong
 
         // Advanced Reverb Tuning (expert mode)
         private bool advancedReverbTuningEnabled = false;
-        private int reverbWetGainMultiplier = 8;     // 1-25 (displayed as 0.01-0.25, stored as 1-25 for int slider)
+        private int reverbWetGainMultiplier = 3;     // 1-25 (displayed as 0.01-0.25, stored as 1-25 for int slider)
         private int reverbAllpassFeedback = 50;     // 30-70 (displayed as 0.30-0.70)
         private int reverbHfDampingMin = 20;        // 10-40 (displayed as 0.10-0.40)
         private int reverbHfDampingMax = 50;        // 30-70 (displayed as 0.30-0.70)

--- a/UniPlaySongSettingsView.xaml
+++ b/UniPlaySongSettingsView.xaml
@@ -698,7 +698,7 @@
                                 TickPlacement="BottomRight"
                                 Margin="10,0,0,0"/>
                     </StackPanel>
-                    <TextBlock Text="Scales reverb intensity (0.01-0.25). Default: 0.08. Higher = more reverb but risk of distortion. Values &gt;0.15 can be VERY loud!"
+                    <TextBlock Text="Scales reverb intensity (0.01-0.25). Default: 0.03. Higher = more reverb but risk of distortion. Values &gt;0.15 can be VERY loud!"
                                FontSize="11"
                                Foreground="Gray"
                                TextWrapping="Wrap"


### PR DESCRIPTION
- **Audacity-Compatible Reverb**: Professional-grade reverb using libSoX/Freeverb algorithm
  - 18 Audacity factory presets (Acoustic, Ambience, Cathedral, etc.)

- **Advanced Reverb Tuning**: Expert-mode controls with safety warnings
  - Wet Gain Multiplier (0.01-0.25, default 0.03)
  - HF Damping Min/Max range controls
- **High-Pass & Low-Pass Filters**: Configurable cutoff frequencies with real-time adjustment

Bug Fixes (based on Cursor Bugbot reports)
- Room size slider now applies in real-time during playback
- Stop() no longer incorrectly triggers MediaEnded event in NAudio player
- Music properly restarts when toggling Live Effects on/off

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements live, safer audio effects behavior and updates defaults for balanced reverb.
> 
> - Reinitialize reverb buffers on `ReverbRoomSize` change in `EffectsChain` for real-time room-size updates
> - Prevent spurious `MediaEnded` by detaching `PlaybackStopped` during `NAudioMusicPlayer.Stop()`
> - `RecreateMusicPlayerForLiveEffects()` now preserves current game/state and restarts playback after switching players
> - Set default reverb `WetGainMultiplier` to `0.03`; update settings default and UI help text
> - Update `CHANGELOG.md` to reflect changes and fixes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0bd2938c877063657131c0a6942ad4a2011ac4c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->