### PR TITLE
Fix audio stuttering by increasing timer interval

### DIFF
--- a/Monitors/MediaElementsMonitor.cs
+++ b/Monitors/MediaElementsMonitor.cs
@@ -49,7 +49,7 @@ namespace UniPlaySong.Monitors
             EventManager.RegisterClassHandler(typeof(MediaElement), MediaElement.MediaOpenedEvent, new RoutedEventHandler(MediaElement_Opened));
 
             timer = new DispatcherTimer();
-            timer.Interval = TimeSpan.FromMilliseconds(10);
+            timer.Interval = TimeSpan.FromMilliseconds(100);
             timer.Tick += Timer_Tick;
             
             Logger.Info($"[UniPlaySong] MediaElementsMonitor: Timer created (interval: 10ms), waiting for MediaElement_Opened to start");


### PR DESCRIPTION
Increased the update timer from 10ms to 100ms. The 10ms interval was too fast and caused race conditions with video framerates, leading to audio stuttering. Tested locally and 100ms solved the issue completely.